### PR TITLE
Fix the case where `status.replicas` is None

### DIFF
--- a/kwait/drivers.py
+++ b/kwait/drivers.py
@@ -80,15 +80,19 @@ class BaseDriver(abc.ABC):
             return result
         ```
         """
-        if obj.status.replicas != obj.spec.replicas:
+        status_replicas = obj.status.replicas or 0
+        if (
+            status_replicas  # pylint: disable=consider-using-assignment-expr
+            != obj.spec.replicas
+        ):
             _LOG.debug(
                 "%s has %s/%s replicas",
                 self.resource,
-                obj.status.replicas,
+                status_replicas,
                 obj.spec.replicas,
             )
             return self.not_ready(
-                f"{obj.status.replicas}/{obj.spec.replicas} replicas exist",
+                f"{status_replicas}/{obj.spec.replicas} replicas exist",
             )
 
         if obj.status.ready_replicas != obj.spec.replicas:

--- a/test/test_drivers.py
+++ b/test/test_drivers.py
@@ -225,6 +225,11 @@ class TestDeployment(ReplicasDriverTest):
         deployment.status.conditions = []
         self.basic_test(deployment, state="no conditions")
 
+    def test_status_replicas_none(self) -> None:
+        obj = self.get_object()
+        obj.status.replicas = None
+        self.basic_test(obj, state=f"0/{obj.spec.replicas} replicas exist")
+
 
 class TestPersistentVolumeClaim(DriverTest):
     driver_cls = drivers.PersistentVolumeClaim


### PR DESCRIPTION
Mostly a formatting bug, no error in behavior.